### PR TITLE
リーディングリスト管理機能の実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",
     "@tailwindcss/vite": "^4.1.12",
+    "@types/chrome": "^0.1.9",
     "@types/node": "^24.3.0",
     "@vitest/coverage-v8": "^3.2.4",
     "jsdom": "^26.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.12
         version: 4.1.12(vite@7.1.5(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1))
+      '@types/chrome':
+        specifier: ^0.1.9
+        version: 0.1.9
       '@types/node':
         specifier: ^24.3.0
         version: 24.3.0
@@ -533,11 +536,23 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
+  '@types/chrome@0.1.9':
+    resolution: {integrity: sha512-Tjzql/wuGkC4Q3FWSziPMbggN0FwQZph4WFhzvnBfmnipzX1vtNBNToAGGpSqAAf26wfKFfZTZmxN8+pgMK9Rw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/filesystem@0.0.36':
+    resolution: {integrity: sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==}
+
+  '@types/filewriter@0.0.33':
+    resolution: {integrity: sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==}
+
+  '@types/har-format@1.2.16':
+    resolution: {integrity: sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==}
 
   '@types/node@24.3.0':
     resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
@@ -1544,9 +1559,22 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
+  '@types/chrome@0.1.9':
+    dependencies:
+      '@types/filesystem': 0.0.36
+      '@types/har-format': 1.2.16
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/filesystem@0.0.36':
+    dependencies:
+      '@types/filewriter': 0.0.33
+
+  '@types/filewriter@0.0.33': {}
+
+  '@types/har-format@1.2.16': {}
 
   '@types/node@24.3.0':
     dependencies:

--- a/src/backend/background.ts
+++ b/src/backend/background.ts
@@ -1,0 +1,79 @@
+// Chrome Extension Background Script for Reading List Management
+
+/// <reference types="chrome" />
+
+/**
+ * Reading List エントリを取得する関数
+ * @returns Promise<chrome.readingList.ReadingListEntry[]> リーディングリストのエントリ一覧
+ */
+async function getReadingListEntries(): Promise<
+  chrome.readingList.ReadingListEntry[]
+> {
+  try {
+    console.log("リーディングリストエントリの取得を開始します...");
+
+    // Chrome Reading List API を使用してエントリを取得
+    const entries = await chrome.readingList.query({});
+
+    console.log(
+      `リーディングリストから ${entries.length} 件のエントリを取得しました`,
+    );
+
+    // 各エントリの詳細をログ出力
+    entries.forEach(
+      (entry: chrome.readingList.ReadingListEntry, index: number) => {
+        console.log(`エントリ ${index + 1}:`, {
+          title: entry.title,
+          url: entry.url,
+          hasBeenRead: entry.hasBeenRead,
+          creationTime: new Date(entry.creationTime).toISOString(),
+          lastUpdateTime: new Date(entry.lastUpdateTime).toISOString(),
+        });
+      },
+    );
+
+    return entries;
+  } catch (error) {
+    console.error("リーディングリストエントリの取得に失敗しました:", error);
+    throw error;
+  }
+}
+
+/**
+ * エクステンション起動時の初期化処理
+ */
+function initializeExtension(): void {
+  chrome.runtime.onStartup.addListener(async () => {
+    console.log("Reading List Auto Summary エクステンションが起動しました");
+    try {
+      await getReadingListEntries();
+    } catch (error) {
+      console.error("初期化時のエントリ取得でエラーが発生しました:", error);
+    }
+  });
+
+  /**
+   * エクステンションインストール時の処理
+   */
+  chrome.runtime.onInstalled.addListener(async () => {
+    console.log(
+      "Reading List Auto Summary エクステンションがインストールされました",
+    );
+    try {
+      await getReadingListEntries();
+    } catch (error) {
+      console.error(
+        "インストール時のエントリ取得でエラーが発生しました:",
+        error,
+      );
+    }
+  });
+}
+
+// Chrome Extension環境でのみ初期化処理を実行
+if (typeof chrome !== "undefined" && chrome.runtime) {
+  initializeExtension();
+}
+
+// エクスポート（テスト用）
+export { getReadingListEntries, initializeExtension };

--- a/src/backend/background.ts
+++ b/src/backend/background.ts
@@ -10,26 +10,24 @@ async function getReadingListEntries(): Promise<
   chrome.readingList.ReadingListEntry[]
 > {
   try {
-    console.log("リーディングリストエントリの取得を開始します...");
+    console.debug("リーディングリストエントリの取得を開始します...");
 
     // Chrome Reading List API を使用してエントリを取得
     const entries = await chrome.readingList.query({});
 
-    console.log(
+    console.debug(
       `リーディングリストから ${entries.length} 件のエントリを取得しました`,
     );
 
-    // 各エントリの詳細をログ出力
-    entries.forEach(
-      (entry: chrome.readingList.ReadingListEntry, index: number) => {
-        console.log(`エントリ ${index + 1}:`, {
-          title: entry.title,
-          url: entry.url,
-          hasBeenRead: entry.hasBeenRead,
-          creationTime: new Date(entry.creationTime).toISOString(),
-          lastUpdateTime: new Date(entry.lastUpdateTime).toISOString(),
-        });
-      },
+    // 各エントリの詳細をテーブル形式でログ出力
+    console.table(
+      entries.map((entry: chrome.readingList.ReadingListEntry) => ({
+        title: entry.title,
+        url: entry.url,
+        hasBeenRead: entry.hasBeenRead,
+        creationTime: new Date(entry.creationTime).toISOString(),
+        lastUpdateTime: new Date(entry.lastUpdateTime).toISOString(),
+      })),
     );
 
     return entries;
@@ -44,7 +42,7 @@ async function getReadingListEntries(): Promise<
  */
 function initializeExtension(): void {
   chrome.runtime.onStartup.addListener(async () => {
-    console.log("Reading List Auto Summary エクステンションが起動しました");
+    console.debug("Reading List Auto Summary エクステンションが起動しました");
     try {
       await getReadingListEntries();
     } catch (error) {
@@ -56,7 +54,7 @@ function initializeExtension(): void {
    * エクステンションインストール時の処理
    */
   chrome.runtime.onInstalled.addListener(async () => {
-    console.log(
+    console.debug(
       "Reading List Auto Summary エクステンションがインストールされました",
     );
     try {

--- a/tests/backend/background.test.ts
+++ b/tests/backend/background.test.ts
@@ -1,7 +1,122 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getReadingListEntries,
+  initializeExtension,
+} from "../../src/backend/background";
+
+// Chrome API のモック
+const mockChrome = {
+  readingList: {
+    query: vi.fn(),
+  },
+  runtime: {
+    onStartup: {
+      addListener: vi.fn(),
+    },
+    onInstalled: {
+      addListener: vi.fn(),
+    },
+  },
+};
+
+// グローバルオブジェクトにchromeを設定
+vi.stubGlobal("chrome", mockChrome);
+
+// テスト用のサンプルデータ
+const sampleEntries: chrome.readingList.ReadingListEntry[] = [
+  {
+    title: "テストエントリ1",
+    url: "https://example.com/1",
+    hasBeenRead: false,
+    creationTime: Date.now() - 86400000, // 1日前
+    lastUpdateTime: Date.now() - 3600000, // 1時間前
+  },
+  {
+    title: "テストエントリ2",
+    url: "https://example.com/2",
+    hasBeenRead: true,
+    creationTime: Date.now() - 172800000, // 2日前
+    lastUpdateTime: Date.now() - 7200000, // 2時間前
+  },
+];
 
 describe("Background", () => {
-  it("dummy", () => {
-    expect(true).toBe(true);
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getReadingListEntries", () => {
+    it("正常系: リーディングリストのエントリを正常に取得できる", async () => {
+      // モックの設定
+      mockChrome.readingList.query.mockResolvedValue(sampleEntries);
+
+      // テスト実行
+      const result = await getReadingListEntries();
+
+      // 検証
+      expect(mockChrome.readingList.query).toHaveBeenCalledWith({});
+      expect(result).toEqual(sampleEntries);
+      expect(result).toHaveLength(2);
+      expect(result[0]?.title).toBe("テストエントリ1");
+      expect(result[1]?.hasBeenRead).toBe(true);
+    });
+
+    it("正常系: エントリが空の場合でも正常に処理される", async () => {
+      // モックの設定
+      mockChrome.readingList.query.mockResolvedValue([]);
+
+      // テスト実行
+      const result = await getReadingListEntries();
+
+      // 検証
+      expect(mockChrome.readingList.query).toHaveBeenCalledWith({});
+      expect(result).toEqual([]);
+      expect(result).toHaveLength(0);
+    });
+
+    it("異常系: Chrome API呼び出しが失敗した場合にエラーをthrowする", async () => {
+      // モックの設定
+      const errorMessage = "Chrome API エラー";
+      mockChrome.readingList.query.mockRejectedValue(new Error(errorMessage));
+
+      // テスト実行と検証
+      await expect(getReadingListEntries()).rejects.toThrow(errorMessage);
+      expect(mockChrome.readingList.query).toHaveBeenCalledWith({});
+    });
+
+    it("異常系: Chrome readingList APIが利用できない場合", async () => {
+      // モックの設定
+      mockChrome.readingList.query.mockRejectedValue(
+        new Error("readingList API is not available"),
+      );
+
+      // テスト実行と検証
+      await expect(getReadingListEntries()).rejects.toThrow(
+        "readingList API is not available",
+      );
+      expect(mockChrome.readingList.query).toHaveBeenCalledWith({});
+    });
+  });
+
+  describe("initializeExtension", () => {
+    it("正常系: イベントリスナーが正しく設定される", () => {
+      // テスト実行
+      initializeExtension();
+
+      // 検証
+      expect(mockChrome.runtime.onStartup.addListener).toHaveBeenCalledTimes(1);
+      expect(mockChrome.runtime.onInstalled.addListener).toHaveBeenCalledTimes(
+        1,
+      );
+
+      // リスナーが関数であることを確認
+      const onStartupCallback =
+        mockChrome.runtime.onStartup.addListener.mock.calls[0]?.[0];
+      const onInstalledCallback =
+        mockChrome.runtime.onInstalled.addListener.mock.calls[0]?.[0];
+
+      expect(typeof onStartupCallback).toBe("function");
+      expect(typeof onInstalledCallback).toBe("function");
+    });
   });
 });


### PR DESCRIPTION
fix: #2 AIによる自動PR

## 実装内容の説明
Issue #2「リーディングリスト管理機能の実装」に対応して、Chrome Extension のリーディングリスト管理機能を実装しました。

### 主な実装内容
- `chrome.readingList.query()` API を使用したリーディングリストエントリ取得機能
- コンソールログによるエントリ情報の確認機能
- エラーハンドリングを含む堅牢な実装
- 包括的なユニットテスト（正常系・異常系・空配列のテスト）

### ファイル修正内容
- `src/backend/background.ts`: メイン機能の実装
- `tests/backend/background.test.ts`: ユニットテスト実装
- `package.json`, `pnpm-lock.yaml`: @types/chrome 依存関係追加

## 実装にあたって参考にした情報や、特に注意した点
- Chrome Extension Manifest V3 のService Workerパターンに準拠
- chrome.readingList APIの型安全性のため@types/chromeを追加
- テスト時にchromeオブジェクトが未定義で失敗しないよう、初期化処理を関数化して条件分岐を追加
- Vitestでのモック作成にvi.stubGlobalを使用してchrome APIをモック化

## 実装にあたっての質問や懸念点
- リーディングリストエントリの表示形式（現在はconsole.log）
- 実際のChrome Extension環境でのテストが必要
- 今後のUI実装時の表示方法について